### PR TITLE
Create docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,5 +15,3 @@ RUN poetry config virtualenvs.create false
 RUN poetry install --no-dev
 
 ENTRYPOINT ["python3", "/app/catchit/catchit.py", "--scan-path"]
-
-CMD ["directory-path"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.8-slim
+
+RUN mkdir /app
+
+COPY . /app
+
+WORKDIR /app
+
+ENV PYTHONPATH=${PYTHONPATH}:${PWD} 
+
+RUN pip3 install poetry
+
+RUN poetry config virtualenvs.create false
+
+RUN poetry install --no-dev
+
+ENTRYPOINT ["python3", "/app/catchit/catchit.py", "--scan-path"]
+
+CMD ["directory-path"]


### PR DESCRIPTION
Created a docker image for catchIt, where the folder to be scanned is passed as an argument to the docker container. Example: `docker run <name-of-docker-image> <folder-to-be-scanned>` . After review, I can raise a PR to work with @TheJuanAndOnly99 to host it on the FINOS docker hub.

@TheJuanAndOnly99 is this possible? @mcleo-d said to contact your for FINOS docker hub issues.

This is a resolution to PR #5 @anirudnits 


